### PR TITLE
Modify interface to allow client to choose which service to connect to

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -28,10 +28,9 @@ Sites using the proposed API would still need to be configured to work with each
 Usage of the API would begin with a call to `Window.getDigitalGoodsService()`, which returns a promise yielding null if there is no DigitalGoodsService:
 
 ```js
-const itemService = await getDigitalGoodsService();
-if (itemService === null ||
-    itemService.paymentMethod !== "https://example.com/billing") {
-    // Not using our preferred item service.
+const itemService = await getDigitalGoodsService("https://example.com/billing");
+if (itemService === null) {
+    // Our preferred item service is not available.
     // Use a normal web-based payment flow.
     return;
 }
@@ -91,16 +90,12 @@ itemService.acknowledge(purchaseToken);
 
 ```webidl
 partial interface Window {
-  // Resolves the promise with null if the website is not running in an environment
-  // where a product service is available.
-  Promise<DigitalGoodsService?> getDigitalGoodsService();
+  // Resolves the promise with null if the product service associated with the
+  // given payment method is unavailable.
+  Promise<DigitalGoodsService?> getDigitalGoodsService(DOMString paymentMethod);
 };
 
 interface DigitalGoodsService {
-  // The payment method identifier to use for purchases in conjunction with this
-  // service.
-  DOMString paymentMethod;
-
   Promise<sequence<ItemDetails>> getDetails(sequence<ItemId> itemIds);
 
   Promise<void> acknowledge(PurchaseToken purchaseToken,


### PR DESCRIPTION
The payment method identifier is now given as a parameter to `getDigitalGoodsService`, rather than returned as a property. This allows the user agent to expose multiple services, letting the client choose which one to use.

Closes #1.
Closes #8.