### PR TITLE
Remove "unknown" PurchaseState

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -148,14 +148,13 @@ dictionary PurchaseDetails {
   required DOMString itemId;
   required DOMString purchaseToken;
   boolean acknowledged = "false";
-  PurchaseState purchaseState = "unknown";
+  PurchaseState purchaseState;
   // Timestamp in ms since 1970-01-01 00:00 UTC.
   DOMTimeStamp purchaseTime;
   boolean willAutoRenew = "false";
 };
 
 enum PurchaseState {
-  "unknown",
   "purchased",
   "pending",
 };


### PR DESCRIPTION
The purchaseState can instead be omitted from the PurchaseDetails dictionary if missing.
Fixes #17